### PR TITLE
feat: Add M2 semantic memory layer with schema, processing status, an…

### DIFF
--- a/scripts/database_manager.py
+++ b/scripts/database_manager.py
@@ -219,6 +219,125 @@ CREATE TRIGGER trigger_m1_embedding_notification
     EXECUTE FUNCTION notify_m1_embedding_needed();
 """
 
+M2_TABLE_SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS m2_semantic (
+    -- Primary identification
+    fact_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+
+    -- Fact content
+    text TEXT NOT NULL,
+
+    -- Idempotency hash for duplicate detection
+    hash TEXT UNIQUE,
+
+    -- Vector embedding (384 dimensions for sentence-transformers/all-MiniLM-L6-v2)
+    embedding vector(384),
+
+    -- Confidence score
+    confidence FLOAT NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0),
+
+    -- Status management
+    status VARCHAR(20) NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'deprecated')),
+
+    -- Source tracking (links back to M1 chunks)
+    chunk_ids UUID[] NOT NULL DEFAULT '{}',
+
+    -- User context
+    user_id UUID NOT NULL,
+
+    -- Policy versioning for extraction tracking
+    policy_version TEXT,
+
+    -- Temporal tracking
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    embedding_generated_at TIMESTAMP WITH TIME ZONE,
+
+    -- Quality metrics
+    embedding_model VARCHAR(100) DEFAULT 'sentence-transformers/all-MiniLM-L6-v2',
+
+    -- General metadata
+    metadata JSONB DEFAULT '{}'::jsonb,
+
+    -- Constraints
+    CONSTRAINT m2_semantic_chunk_lineage_not_empty
+        CHECK (array_length(chunk_ids, 1) > 0)
+);
+"""
+
+M2_INDEXES_SQL = [
+    "CREATE INDEX IF NOT EXISTS idx_m2_embedding_hnsw ON m2_semantic USING hnsw (embedding vector_cosine_ops) WITH (m = 16, ef_construction = 64);",
+    "CREATE INDEX IF NOT EXISTS idx_m2_user_id ON m2_semantic (user_id);",
+    "CREATE INDEX IF NOT EXISTS idx_m2_status ON m2_semantic (status);",
+    "CREATE INDEX IF NOT EXISTS idx_m2_confidence ON m2_semantic (confidence);",
+    "CREATE INDEX IF NOT EXISTS idx_m2_created_at ON m2_semantic (created_at DESC);",
+    "CREATE INDEX IF NOT EXISTS idx_m2_updated_at ON m2_semantic (updated_at DESC);",
+    "CREATE INDEX IF NOT EXISTS idx_m2_policy_version ON m2_semantic (policy_version);",
+    "CREATE INDEX IF NOT EXISTS idx_m2_hash ON m2_semantic (hash);",
+    "CREATE INDEX IF NOT EXISTS idx_m2_chunk_ids_gin ON m2_semantic USING gin (chunk_ids);",
+    "CREATE INDEX IF NOT EXISTS idx_m2_metadata_gin ON m2_semantic USING gin (metadata);"
+]
+
+M2_UPDATE_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION update_m2_semantic_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+M2_UPDATE_TRIGGER_SQL = """
+DROP TRIGGER IF EXISTS trigger_update_m2_semantic_updated_at ON m2_semantic;
+CREATE TRIGGER trigger_update_m2_semantic_updated_at
+    BEFORE UPDATE ON m2_semantic
+    FOR EACH ROW
+    EXECUTE FUNCTION update_m2_semantic_updated_at();
+"""
+
+M2_EMBEDDING_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION update_m2_embedding_generated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.embedding IS NOT NULL AND OLD.embedding IS NULL THEN
+        NEW.embedding_generated_at = CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+M2_EMBEDDING_TRIGGER_SQL = """
+DROP TRIGGER IF EXISTS trigger_update_m2_embedding_generated_at ON m2_semantic;
+CREATE TRIGGER trigger_update_m2_embedding_generated_at
+    BEFORE UPDATE ON m2_semantic
+    FOR EACH ROW
+    EXECUTE FUNCTION update_m2_embedding_generated_at();
+"""
+
+M2_NOTIFICATION_FUNCTION_SQL = """
+CREATE OR REPLACE FUNCTION notify_m2_embedding_needed()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Notify embedding system when new facts are created without embeddings
+    IF NEW.embedding IS NULL AND NEW.text IS NOT NULL THEN
+        PERFORM pg_notify('embedding_needed', 'm2_semantic:' || NEW.fact_id::text);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+"""
+
+M2_EMBEDDING_NOTIFICATION_TRIGGER_SQL = """
+DROP TRIGGER IF EXISTS trigger_m2_embedding_notification ON m2_semantic;
+CREATE TRIGGER trigger_m2_embedding_notification
+    AFTER INSERT ON m2_semantic
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_m2_embedding_needed();
+"""
+
 # Note: This implements MemFuse's custom pgai-like functionality
 # We don't need TimescaleDB's pgai extension as we have our own event-driven embedding system
 
@@ -421,6 +540,20 @@ class DatabaseManager:
             if count_result:
                 status['m0_raw_count'] = int(count_result.strip())
                 print(f"m0_raw records: {status['m0_raw_count']}")
+
+        # Check m1_episodic specifically
+        if 'm1_episodic' in status['tables']:
+            count_result = self.run_sql_command("SELECT COUNT(*) FROM m1_episodic;", "tuples")
+            if count_result:
+                status['m1_episodic_count'] = int(count_result.strip())
+                print(f"m1_episodic records: {status['m1_episodic_count']}")
+
+        # Check m2_semantic specifically
+        if 'm2_semantic' in status['tables']:
+            count_result = self.run_sql_command("SELECT COUNT(*) FROM m2_semantic;", "tuples")
+            if count_result:
+                status['m2_semantic_count'] = int(count_result.strip())
+                print(f"m2_semantic records: {status['m2_semantic_count']}")
         
         # Check triggers
         trigger_result = self.run_sql_command("""
@@ -565,6 +698,15 @@ class DatabaseManager:
             self.print_status("Failed to create m1_episodic table", StatusLevel.ERROR)
             return False
 
+        # Create m2_semantic table
+        self.print_status("Creating m2_semantic table...", StatusLevel.INFO)
+        result = self.run_sql_command(M2_TABLE_SCHEMA_SQL)
+        if result is not None:
+            self.print_status("m2_semantic table created successfully", StatusLevel.SUCCESS)
+        else:
+            self.print_status("Failed to create m2_semantic table", StatusLevel.ERROR)
+            return False
+
         # Create M0 indexes
         self.print_status("Creating M0 indexes...", StatusLevel.INFO)
         m0_index_success_count = 0
@@ -587,8 +729,19 @@ class DatabaseManager:
             else:
                 self.print_status("Failed to create M1 index", StatusLevel.WARNING)
 
-        total_indexes = len(M0_INDEXES_SQL) + len(M1_INDEXES_SQL)
-        total_success = m0_index_success_count + m1_index_success_count
+        # Create M2 indexes
+        self.print_status("Creating M2 indexes...", StatusLevel.INFO)
+        m2_index_success_count = 0
+        for index_sql in M2_INDEXES_SQL:
+            result = self.run_sql_command(index_sql)
+            if result is not None:
+                m2_index_success_count += 1
+                self.print_status("M2 index created successfully", StatusLevel.SUCCESS)
+            else:
+                self.print_status("Failed to create M2 index", StatusLevel.WARNING)
+
+        total_indexes = len(M0_INDEXES_SQL) + len(M1_INDEXES_SQL) + len(M2_INDEXES_SQL)
+        total_success = m0_index_success_count + m1_index_success_count + m2_index_success_count
 
         if total_success == 0:
             self.print_status("Failed to create any indexes", StatusLevel.ERROR)
@@ -652,6 +805,57 @@ class DatabaseManager:
         else:
             self.print_status("Failed to create M1 embedding trigger", StatusLevel.ERROR)
             return False
+
+        # Create M2 trigger system
+        self.print_status("Creating M2 trigger system...", StatusLevel.INFO)
+
+        # Create M2 update function
+        result = self.run_sql_command(M2_UPDATE_FUNCTION_SQL)
+        if result is not None:
+            self.print_status("M2 update function created successfully", StatusLevel.SUCCESS)
+        else:
+            self.print_status("Failed to create M2 update function", StatusLevel.ERROR)
+            return False
+
+        # Create M2 update trigger
+        result = self.run_sql_command(M2_UPDATE_TRIGGER_SQL)
+        if result is not None:
+            self.print_status("M2 update trigger created successfully", StatusLevel.SUCCESS)
+        else:
+            self.print_status("Failed to create M2 update trigger", StatusLevel.ERROR)
+            return False
+
+        # Create M2 embedding function
+        result = self.run_sql_command(M2_EMBEDDING_FUNCTION_SQL)
+        if result is not None:
+            self.print_status("M2 embedding function created successfully", StatusLevel.SUCCESS)
+        else:
+            self.print_status("Failed to create M2 embedding function", StatusLevel.ERROR)
+            return False
+
+        # Create M2 embedding trigger
+        result = self.run_sql_command(M2_EMBEDDING_TRIGGER_SQL)
+        if result is not None:
+            self.print_status("M2 embedding trigger created successfully", StatusLevel.SUCCESS)
+        else:
+            self.print_status("Failed to create M2 embedding trigger", StatusLevel.ERROR)
+            return False
+
+        # Create M2 notification function
+        result = self.run_sql_command(M2_NOTIFICATION_FUNCTION_SQL)
+        if result is not None:
+            self.print_status("M2 notification function created successfully", StatusLevel.SUCCESS)
+        else:
+            self.print_status("Failed to create M2 notification function", StatusLevel.ERROR)
+            return False
+
+        # Create M2 embedding notification trigger
+        result = self.run_sql_command(M2_EMBEDDING_NOTIFICATION_TRIGGER_SQL)
+        if result is not None:
+            self.print_status("M2 embedding notification trigger created successfully", StatusLevel.SUCCESS)
+        else:
+            self.print_status("Failed to create M2 embedding notification trigger", StatusLevel.ERROR)
+            return False
         
         print("\n✅ Database schema recreation completed successfully")
         return True
@@ -711,6 +915,41 @@ class DatabaseManager:
         else:
             validation_results.append(("vector extension", False))
             print("❌ Vector extension missing")
+
+        # Check m2_semantic table
+        table_result = self.run_sql_command("\\d m2_semantic")
+        if table_result and 'fact_id' in table_result and 'embedding' in table_result:
+            validation_results.append(("m2_semantic table", True))
+            print("✅ m2_semantic table exists with correct structure")
+        else:
+            validation_results.append(("m2_semantic table", False))
+            print("❌ m2_semantic table missing or incorrect")
+        
+        # Check M2 update trigger
+        m2_trigger_result = self.run_sql_command("""
+            SELECT COUNT(*) FROM information_schema.triggers
+            WHERE trigger_name = 'trigger_update_m2_semantic_updated_at';
+        """, "tuples")
+        
+        if m2_trigger_result and int(m2_trigger_result.strip()) > 0:
+            validation_results.append(("M2 update trigger", True))
+            print("✅ M2 update trigger configured")
+        else:
+            validation_results.append(("M2 update trigger", False))
+            print("❌ M2 update trigger missing")
+        
+        # Check M2 embedding notification trigger
+        m2_embedding_trigger_result = self.run_sql_command("""
+            SELECT COUNT(*) FROM information_schema.triggers
+            WHERE trigger_name = 'trigger_m2_embedding_notification';
+        """, "tuples")
+        
+        if m2_embedding_trigger_result and int(m2_embedding_trigger_result.strip()) > 0:
+            validation_results.append(("M2 embedding notification trigger", True))
+            print("✅ M2 embedding notification trigger configured")
+        else:
+            validation_results.append(("M2 embedding notification trigger", False))
+            print("❌ M2 embedding notification trigger missing")
         
         # Summary
         passed = sum(1 for _, result in validation_results if result)

--- a/src/memfuse_core/hierarchy/layers.py
+++ b/src/memfuse_core/hierarchy/layers.py
@@ -842,20 +842,23 @@ class M2SemanticLayer(MemoryLayer):
         self.llm_config = config.custom_config.get("llm_config", {})
         self.fact_extraction_enabled = config.custom_config.get("fact_extraction_enabled", True)
 
-        logger.info(f"M2SemanticLayer: Initialized for user {user_id}")
+        logger.info(f"[M2-DEBUG] M2SemanticLayer: Initialized for user {user_id}")
     
     async def initialize(self) -> bool:
         """Initialize the M2 layer."""
+        logger.info(f"[M2-DEBUG] M2SemanticLayer.initialize() called for user {self.user_id}")
         try:
             if self.storage_manager:
+                logger.info(f"[M2-DEBUG] M2SemanticLayer: Calling storage_manager.initialize() for user {self.user_id}")
                 await self.storage_manager.initialize()
+                logger.info(f"[M2-DEBUG] M2SemanticLayer: storage_manager.initialize() completed for user {self.user_id}")
 
             self.initialized = True
-            logger.info(f"M2SemanticLayer: Initialized successfully for user {self.user_id}")
+            logger.info(f"[M2-DEBUG] M2SemanticLayer: Initialized successfully for user {self.user_id}")
             return True
 
         except Exception as e:
-            logger.error(f"M2SemanticLayer: Initialization failed: {e}")
+            logger.error(f"[M2-DEBUG] M2SemanticLayer: Initialization failed: {e}")
             return False
     
     async def process_data(self, data: Any, metadata: Optional[Dict[str, Any]] = None) -> ProcessingResult:

--- a/src/memfuse_core/hierarchy/manager.py
+++ b/src/memfuse_core/hierarchy/manager.py
@@ -94,12 +94,17 @@ class MemoryHierarchyManager:
 
             # M2 Layer
             if layers_config.get("m2", {}).get("enabled", True):
+                logger.info(f"[M2-DEBUG] HierarchyManager: Creating M2 layer for user {self.user_id}")
                 m2_config = self._create_layer_config(layers_config.get("m2", {}))
                 self.layers[LayerType.M2] = M2SemanticLayer(
                     LayerType.M2, m2_config, self.user_id,
                     self.storage_manager
                 )
+                logger.info(f"[M2-DEBUG] HierarchyManager: Initializing M2 layer for user {self.user_id}")
                 await self.layers[LayerType.M2].initialize()
+                logger.info(f"[M2-DEBUG] HierarchyManager: M2 layer initialized for user {self.user_id}")
+            else:
+                logger.info(f"[M2-DEBUG] HierarchyManager: M2 layer disabled for user {self.user_id}")
 
             # M3 Layer (Placeholder)
             if layers_config.get("m3", {}).get("enabled", False):  # Default disabled

--- a/src/memfuse_core/models/core.py
+++ b/src/memfuse_core/models/core.py
@@ -12,6 +12,13 @@ from enum import Enum
 
 
 # Type definitions
+class M2Status(str, Enum):
+    PENDING = "pending"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
 class StoreBackend(str, Enum):
     """Store backend types."""
 

--- a/src/memfuse_core/services/simplified_memory_service.py
+++ b/src/memfuse_core/services/simplified_memory_service.py
@@ -93,13 +93,13 @@ class SimplifiedDatabaseManager:
             with self.conn.cursor() as cur:
                 cur.execute("""
                     SELECT table_name FROM information_schema.tables
-                    WHERE table_schema = 'public' AND table_name IN ('users', 'sessions', 'rounds', 'messages', 'm0_raw', 'm1_episodic')
+                    WHERE table_schema = 'public' AND table_name IN ('users', 'sessions', 'rounds', 'messages', 'm0_raw', 'm1_episodic', 'm2_semantic')
                 """)
                 existing_tables = [row[0] for row in cur.fetchall()]
 
                 # Create missing basic tables
                 missing_tables = []
-                required_tables = ['users', 'sessions', 'rounds', 'messages', 'm0_raw', 'm1_episodic']
+                required_tables = ['users', 'sessions', 'rounds', 'messages', 'm0_raw', 'm1_episodic', 'm2_semantic']
                 for table in required_tables:
                     if table not in existing_tables:
                         missing_tables.append(table)
@@ -183,8 +183,8 @@ class SimplifiedDatabaseManager:
                     ''')
                     logger.info("✅ Created messages table")
 
-                # Create M0 and M1 tables using SchemaManager
-                if 'm0_raw' in missing_tables or 'm1_episodic' in missing_tables:
+                # Create M0, M1, and M2 tables using SchemaManager and SQL files
+                if 'm0_raw' in missing_tables or 'm1_episodic' in missing_tables or 'm2_semantic' in missing_tables:
                     from memfuse_core.models.schema.manager import SchemaManager
                     schema_manager = SchemaManager()
 
@@ -197,6 +197,11 @@ class SimplifiedDatabaseManager:
                         m1_schema = schema_manager.get_schema('m1_episodic')
                         cur.execute(m1_schema.generate_create_table_sql())
                         logger.info("✅ Created m1_episodic table")
+
+                    if 'm2_semantic' in missing_tables:
+                        # Create M2 table using SQL file (SchemaManager doesn't support M2)
+                        await self._create_m2_semantic_table(cur)
+                        logger.info("✅ Created m2_semantic table")
             # Commit DDL batch
             self.conn.commit()
             # Restore autocommit
@@ -236,6 +241,31 @@ class SimplifiedDatabaseManager:
                     raise Exception(f"Required function '{func_name}' not found")
                 else:
                     logger.debug(f"✅ Function '{func_name}' found")
+
+    async def _create_m2_semantic_table(self, cur) -> None:
+        """Create M2 semantic table using SQL schema file."""
+        import os
+        from pathlib import Path
+        
+        try:
+            # Path to M2 semantic SQL schema file
+            schema_file = Path(__file__).parent.parent / "store" / "pgai_store" / "schemas" / "m2_semantic.sql"
+            
+            if not schema_file.exists():
+                logger.error(f"❌ M2 schema file not found: {schema_file}")
+                raise FileNotFoundError(f"M2 schema file not found: {schema_file}")
+            
+            # Read and execute M2 schema SQL
+            with open(schema_file, 'r') as f:
+                m2_sql = f.read()
+            
+            logger.debug(f"📝 Loading M2 schema from: {schema_file}")
+            cur.execute(m2_sql)
+            logger.debug("✅ M2 semantic table schema executed successfully")
+            
+        except Exception as e:
+            logger.error(f"❌ Failed to create M2 semantic table: {e}")
+            raise
 
     async def health_check(self) -> bool:
         """Perform database health check."""

--- a/src/memfuse_core/store/pgai_store/pgai_store.py
+++ b/src/memfuse_core/store/pgai_store/pgai_store.py
@@ -397,11 +397,11 @@ class PgaiStore(ChunkStoreInterface):
 
     async def _setup_schema(self):
         """Create the messages table schema compatible with existing MemFuse schema."""
-        logger.debug(f"Setting up schema for table: {self.table_name}")
+        logger.debug(f"[M2-DEBUG] Setting up schema for table: {self.table_name}")
 
         # First check if schema is already properly set up
         if await self._is_schema_ready():
-            logger.debug(f"Schema for {self.table_name} is already properly configured")
+            logger.info(f"[M2-DEBUG] Schema already ready for table: {self.table_name}")
             return
 
         logger.debug(f"Schema needs setup for {self.table_name}, proceeding with creation...")
@@ -418,17 +418,23 @@ class PgaiStore(ChunkStoreInterface):
                     schema_file = os.path.join(schema_dir, 'm0_raw.sql')
                 elif self.table_name == 'm1_episodic':
                     schema_file = os.path.join(schema_dir, 'm1_episodic.sql')
+                elif self.table_name == 'm2_semantic':
+                    schema_file = os.path.join(schema_dir, 'm2_semantic.sql')
+                    logger.info(f"[M2-DEBUG] *** M2 SCHEMA CREATION *** table_name={self.table_name}, schema_file={schema_file}")
                 else:
                     # Fallback for other tables - use simplified m0_raw schema
                     schema_file = os.path.join(schema_dir, 'm0_raw.sql')
 
+                logger.info(f"[M2-DEBUG] Selected schema file: {schema_file} for table: {self.table_name}")
+
                 if os.path.exists(schema_file):
                     with open(schema_file, 'r') as f:
                         schema_sql = f.read()
+                    logger.info(f"[M2-DEBUG] Executing schema SQL for {self.table_name}, SQL length: {len(schema_sql)} chars")
                     await conn.execute(schema_sql)
-                    logger.debug(f"Table {self.table_name} created using schema file")
+                    logger.info(f"[M2-DEBUG] *** SUCCESS *** Table {self.table_name} created using schema file")
                 else:
-                    logger.warning(f"Schema file not found: {schema_file}, using fallback")
+                    logger.warning(f"[M2-DEBUG] *** ERROR *** Schema file not found: {schema_file}, using fallback")
                     # Fallback to basic table creation
                     await conn.execute(f"""
                         CREATE TABLE IF NOT EXISTS {self.table_name} (

--- a/src/memfuse_core/store/pgai_store/schema_manager.py
+++ b/src/memfuse_core/store/pgai_store/schema_manager.py
@@ -22,7 +22,7 @@ class SchemaManager:
     """
     Schema manager for multi-layer PgAI system.
 
-    Handles database schema creation and validation for M0 and M1 layers
+    Handles database schema creation and validation for M0, M1, and M2 layers
     with their associated triggers, indexes, and embedding infrastructure.
     """
     
@@ -37,7 +37,7 @@ class SchemaManager:
 
         self.pool = pool
         self.schema_dir = Path(__file__).parent / "schemas"
-        self.supported_layers = ["m0", "m1"]
+        self.supported_layers = ["m0", "m1", "m2"]
         
         logger.info("SchemaManager initialized")
     
@@ -45,7 +45,7 @@ class SchemaManager:
         """Initialize schemas for all enabled memory layers.
         
         Args:
-            enabled_layers: List of layer names to initialize (e.g., ['m0', 'm1'])
+            enabled_layers: List of layer names to initialize (e.g., ['m0', 'm1', 'm2'])
             
         Returns:
             True if all schemas initialized successfully
@@ -74,7 +74,7 @@ class SchemaManager:
         """Initialize schema for a specific memory layer.
         
         Args:
-            layer: Layer name ('m0' or 'm1')
+            layer: Layer name ('m0', 'm1', or 'm2')
             
         Returns:
             True if schema initialized successfully
@@ -87,6 +87,8 @@ class SchemaManager:
                 success = await self._initialize_m0_schema()
             elif layer == "m1":
                 success = await self._initialize_m1_schema()
+            elif layer == "m2":
+                success = await self._initialize_m2_schema()
             else:
                 logger.error(f"Unknown layer: {layer}")
                 return False
@@ -188,6 +190,26 @@ class SchemaManager:
             logger.error(f"Failed to create M1 schema: {e}")
             return False
     
+    async def _initialize_m2_schema(self) -> bool:
+        """Initialize M2 semantic memory schema."""
+        try:
+            schema_file = self.schema_dir / "m2_semantic.sql"
+            if not schema_file.exists():
+                logger.error(f"M2 schema file not found: {schema_file}")
+                return False
+            
+            async with self.pool.connection() as conn:
+                schema_sql = schema_file.read_text()
+                await conn.execute(schema_sql)
+                await conn.commit()
+                
+                logger.info("M2 schema created successfully")
+                return True
+                
+        except Exception as e:
+            logger.error(f"Failed to create M2 schema: {e}")
+            return False
+    
     async def validate_schemas(self, enabled_layers: List[str]) -> Dict[str, bool]:
         """Validate schemas for enabled layers.
         
@@ -209,6 +231,8 @@ class SchemaManager:
                     results[layer] = await self._validate_m0_schema()
                 elif layer == "m1":
                     results[layer] = await self._validate_m1_schema()
+                elif layer == "m2":
+                    results[layer] = await self._validate_m2_schema()
                 else:
                     results[layer] = False
                     
@@ -277,4 +301,34 @@ class SchemaManager:
                 
         except Exception as e:
             logger.error(f"M1 schema validation failed: {e}")
+            return False
+    
+    async def _validate_m2_schema(self) -> bool:
+        """Validate M2 schema structure."""
+        try:
+            async with self.pool.connection() as conn:
+                # Check if table exists
+                result = await conn.execute("""
+                    SELECT EXISTS (
+                        SELECT FROM information_schema.tables 
+                        WHERE table_name = 'm2_semantic'
+                    );
+                """)
+                table_exists = (await result.fetchone())[0]
+                
+                if not table_exists:
+                    return False
+                
+                # Check if key columns exist
+                result = await conn.execute("""
+                    SELECT COUNT(*) FROM information_schema.columns 
+                    WHERE table_name = 'm2_semantic'
+                    AND column_name IN ('fact_id', 'text', 'embedding', 'confidence');
+                """)
+                column_count = (await result.fetchone())[0]
+                
+                return column_count >= 4
+                
+        except Exception as e:
+            logger.error(f"M2 schema validation failed: {e}")
             return False

--- a/src/memfuse_core/store/pgai_store/schemas/m1_episodic.sql
+++ b/src/memfuse_core/store/pgai_store/schemas/m1_episodic.sql
@@ -33,6 +33,12 @@ CREATE TABLE IF NOT EXISTS m1_episodic (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     embedding_generated_at TIMESTAMP WITH TIME ZONE,
 
+    -- M2 processing status tracking
+    m2_status VARCHAR(20) DEFAULT 'pending'
+        CHECK (m2_status IN ('pending', 'processing', 'completed', 'failed')),
+    m2_processing_started_at TIMESTAMP WITH TIME ZONE,
+    m2_processing_ended_at TIMESTAMP WITH TIME ZONE,
+
     -- Quality metrics
     embedding_model VARCHAR(100) DEFAULT 'sentence-transformers/all-MiniLM-L6-v2',
     chunk_quality_score FLOAT DEFAULT 0.0,
@@ -80,6 +86,16 @@ CREATE INDEX IF NOT EXISTS idx_m1_chunk_quality_score
 -- GIN index for M0 message ID arrays (lineage queries)
 CREATE INDEX IF NOT EXISTS idx_m1_m0_raw_ids_gin
     ON m1_episodic USING gin (m0_raw_ids);
+
+-- M2 processing status indexes
+CREATE INDEX IF NOT EXISTS idx_m1_m2_status
+    ON m1_episodic (m2_status);
+
+CREATE INDEX IF NOT EXISTS idx_m1_m2_processing_started_at
+    ON m1_episodic (m2_processing_started_at);
+
+CREATE INDEX IF NOT EXISTS idx_m1_m2_processing_ended_at
+    ON m1_episodic (m2_processing_ended_at);
 
 -- =============================================================================
 -- AUTOMATIC TIMESTAMP UPDATE TRIGGER
@@ -155,3 +171,6 @@ COMMENT ON COLUMN m1_episodic.session_id IS 'Session context identifier (unified
 COMMENT ON COLUMN m1_episodic.embedding_generated_at IS 'Timestamp when embedding was generated';
 COMMENT ON COLUMN m1_episodic.embedding_model IS 'Model used for embedding generation';
 COMMENT ON COLUMN m1_episodic.chunk_quality_score IS 'Quality score for the chunk (0.0 to 1.0)';
+COMMENT ON COLUMN m1_episodic.m2_status IS 'M2 fact extraction processing status: pending, processing, completed, or failed';
+COMMENT ON COLUMN m1_episodic.m2_processing_started_at IS 'Timestamp when M2 fact extraction processing started';
+COMMENT ON COLUMN m1_episodic.m2_processing_ended_at IS 'Timestamp when M2 fact extraction processing ended';

--- a/src/memfuse_core/store/pgai_store/schemas/m2_semantic.sql
+++ b/src/memfuse_core/store/pgai_store/schemas/m2_semantic.sql
@@ -1,6 +1,6 @@
 -- M2 Semantic Memory Layer Schema
 -- This schema defines the m2_semantic table for storing semantic facts
--- with automatic embedding generation support
+-- with high-performance vector embeddings optimized for similarity search
 
 -- =============================================================================
 -- M2 SEMANTIC TABLE DEFINITION
@@ -8,102 +8,117 @@
 
 CREATE TABLE IF NOT EXISTS m2_semantic (
     -- Primary identification
-    id TEXT PRIMARY KEY,
-    
-    -- Source tracking (links back to M1 episodic memory)
-    source_id TEXT,  -- References m1_episodic.id
-    source_session_id TEXT,  -- Session context for fact
-    source_user_id TEXT,  -- User context for fact
-    
-    -- Fact content and metadata
-    fact_content TEXT NOT NULL,
-    fact_type TEXT,  -- Open-ended fact type, no constraints for extensibility
-    fact_category JSONB DEFAULT '{}'::jsonb,  -- Flexible categorization system
+    fact_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+
+    -- Fact content
+    text TEXT NOT NULL,
+
+    -- Idempotency hash for duplicate detection
+    hash TEXT UNIQUE,
+
+    -- Vector embedding (384 dimensions for sentence-transformers/all-MiniLM-L6-v2)
+    embedding vector(384),
+
+    -- Confidence score
     confidence FLOAT NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0),
-    
-    -- Structured fact data
-    entities JSONB DEFAULT '[]'::jsonb,  -- Extracted entities from fact
-    temporal_info JSONB DEFAULT '{}'::jsonb,  -- Temporal information (dates, times, etc.)
-    source_context TEXT,  -- Brief context about where fact came from
-    
-    -- Semantic-specific fields
-    is_verified BOOLEAN DEFAULT FALSE,  -- Whether fact has been verified
-    verification_method TEXT,  -- How the fact was verified
-    verification_source TEXT,  -- Source of verification
-    verification_confidence FLOAT,  -- Confidence in verification (0.0 to 1.0)
-    
-    -- Conflict management
-    conflict_status TEXT DEFAULT 'none',  -- none, potential, confirmed
-    conflicting_facts JSONB DEFAULT '[]'::jsonb,  -- References to conflicting facts
-    resolution_status TEXT,  -- How conflicts were resolved
-    
+
+    -- Status management
+    status VARCHAR(20) NOT NULL DEFAULT 'active'
+        CHECK (status IN ('active', 'deprecated')),
+
+    -- Source tracking (links back to M1 chunks)
+    chunk_ids UUID[] NOT NULL DEFAULT '{}',
+
+    -- User context
+    user_id UUID NOT NULL,
+
+    -- Policy versioning for extraction tracking
+    policy_version TEXT,
+
+    -- Temporal tracking
+    created_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    embedding_generated_at TIMESTAMP WITH TIME ZONE,
+
+    -- Quality metrics
+    embedding_model VARCHAR(100) DEFAULT 'sentence-transformers/all-MiniLM-L6-v2',
+
     -- General metadata
     metadata JSONB DEFAULT '{}'::jsonb,
-    
-    -- PgAI embedding infrastructure (identical to M0/M1)
-    embedding VECTOR(384),  -- 384-dimensional embedding vector
-    needs_embedding BOOLEAN DEFAULT TRUE,  -- Flag for automatic embedding generation
-    retry_count INTEGER DEFAULT 0,  -- Number of embedding retry attempts
-    last_retry_at TIMESTAMP,  -- Timestamp of last retry attempt
-    retry_status TEXT DEFAULT 'pending' CHECK (retry_status IN ('pending', 'processing', 'completed', 'failed')),
-    
-    -- Audit timestamps
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+
+    -- Constraints
+    CONSTRAINT m2_semantic_chunk_lineage_not_empty
+        CHECK (array_length(chunk_ids, 1) > 0)
 );
 
 -- =============================================================================
--- PERFORMANCE INDEXES
+-- HIGH-PERFORMANCE VECTOR INDEXES
 -- =============================================================================
 
--- Primary key index (automatic)
--- CREATE UNIQUE INDEX m2_semantic_pkey ON m2_semantic USING btree (id);
+-- HNSW index for optimal vector similarity search
+-- Features:
+-- - Fast approximate nearest neighbor search
+-- - Optimized for 384-dimensional embeddings
+-- - Cosine distance for semantic similarity
+CREATE INDEX IF NOT EXISTS idx_m2_embedding_hnsw
+    ON m2_semantic
+    USING hnsw (embedding vector_cosine_ops)
+    WITH (m = 16, ef_construction = 64);
 
--- Source tracking indexes
-CREATE INDEX IF NOT EXISTS idx_m2_source_id ON m2_semantic (source_id);
-CREATE INDEX IF NOT EXISTS idx_m2_source_session ON m2_semantic (source_session_id);
-CREATE INDEX IF NOT EXISTS idx_m2_source_user ON m2_semantic (source_user_id);
+-- Additional indexes for M2 layer performance
+CREATE INDEX IF NOT EXISTS idx_m2_user_id
+    ON m2_semantic (user_id);
 
--- Fact type and confidence indexes
-CREATE INDEX IF NOT EXISTS idx_m2_fact_type ON m2_semantic (fact_type);
-CREATE INDEX IF NOT EXISTS idx_m2_confidence ON m2_semantic (confidence);
+CREATE INDEX IF NOT EXISTS idx_m2_status
+    ON m2_semantic (status);
 
--- Verification indexes
-CREATE INDEX IF NOT EXISTS idx_m2_is_verified ON m2_semantic (is_verified);
-CREATE INDEX IF NOT EXISTS idx_m2_verification_confidence ON m2_semantic (verification_confidence);
+CREATE INDEX IF NOT EXISTS idx_m2_confidence
+    ON m2_semantic (confidence);
 
--- Conflict management indexes
-CREATE INDEX IF NOT EXISTS idx_m2_conflict_status ON m2_semantic (conflict_status);
-CREATE INDEX IF NOT EXISTS idx_m2_resolution_status ON m2_semantic (resolution_status);
+CREATE INDEX IF NOT EXISTS idx_m2_created_at
+    ON m2_semantic (created_at DESC);
 
--- Auto-embedding query optimization
-CREATE INDEX IF NOT EXISTS idx_m2_needs_embedding ON m2_semantic (needs_embedding) 
-WHERE needs_embedding = TRUE;
+CREATE INDEX IF NOT EXISTS idx_m2_updated_at
+    ON m2_semantic (updated_at DESC);
 
--- Retry management indexes
-CREATE INDEX IF NOT EXISTS idx_m2_retry_status ON m2_semantic (retry_status);
-CREATE INDEX IF NOT EXISTS idx_m2_retry_count ON m2_semantic (retry_count);
+CREATE INDEX IF NOT EXISTS idx_m2_policy_version
+    ON m2_semantic (policy_version);
 
--- Temporal indexes
-CREATE INDEX IF NOT EXISTS idx_m2_created_at ON m2_semantic (created_at);
-CREATE INDEX IF NOT EXISTS idx_m2_updated_at ON m2_semantic (updated_at);
+-- Hash index for duplicate detection
+CREATE INDEX IF NOT EXISTS idx_m2_hash
+    ON m2_semantic (hash);
 
--- JSONB indexes for structured data
-CREATE INDEX IF NOT EXISTS idx_m2_entities_gin ON m2_semantic USING gin (entities);
-CREATE INDEX IF NOT EXISTS idx_m2_temporal_gin ON m2_semantic USING gin (temporal_info);
-CREATE INDEX IF NOT EXISTS idx_m2_metadata_gin ON m2_semantic USING gin (metadata);
-CREATE INDEX IF NOT EXISTS idx_m2_category_gin ON m2_semantic USING gin (fact_category);
-CREATE INDEX IF NOT EXISTS idx_m2_conflicting_facts_gin ON m2_semantic USING gin (conflicting_facts);
+-- GIN index for chunk ID arrays (lineage queries)
+CREATE INDEX IF NOT EXISTS idx_m2_chunk_ids_gin
+    ON m2_semantic USING gin (chunk_ids);
 
--- Vector similarity search index (will be created after data insertion)
--- CREATE INDEX IF NOT EXISTS idx_m2_embedding_cosine ON m2_semantic
---     USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+-- GIN index for metadata queries
+CREATE INDEX IF NOT EXISTS idx_m2_metadata_gin
+    ON m2_semantic USING gin (metadata);
 
 -- =============================================================================
--- TRIGGERS
+-- AUTOMATIC TIMESTAMP UPDATE TRIGGER
 -- =============================================================================
 
--- Create function to update updated_at timestamp
+-- Function to update the embedding_generated_at timestamp when embedding is set
+CREATE OR REPLACE FUNCTION update_m2_embedding_generated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.embedding IS NOT NULL AND OLD.embedding IS NULL THEN
+        NEW.embedding_generated_at = CURRENT_TIMESTAMP;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Trigger to automatically update embedding_generated_at when embedding is created
+DROP TRIGGER IF EXISTS trigger_update_m2_embedding_generated_at ON m2_semantic;
+CREATE TRIGGER trigger_update_m2_embedding_generated_at
+    BEFORE UPDATE ON m2_semantic
+    FOR EACH ROW
+    EXECUTE FUNCTION update_m2_embedding_generated_at();
+
+-- Function to update the updated_at timestamp
 CREATE OR REPLACE FUNCTION update_m2_semantic_updated_at()
 RETURNS TRIGGER AS $$
 BEGIN
@@ -112,95 +127,66 @@ BEGIN
 END;
 $$ LANGUAGE plpgsql;
 
--- Create trigger for automatic updated_at updates
-DROP TRIGGER IF EXISTS m2_semantic_updated_at_trigger ON m2_semantic;
-CREATE TRIGGER m2_semantic_updated_at_trigger
+-- Trigger to automatically update updated_at on changes
+DROP TRIGGER IF EXISTS trigger_update_m2_semantic_updated_at ON m2_semantic;
+CREATE TRIGGER trigger_update_m2_semantic_updated_at
     BEFORE UPDATE ON m2_semantic
     FOR EACH ROW
     EXECUTE FUNCTION update_m2_semantic_updated_at();
 
--- Create notification function for immediate embedding generation
+-- =============================================================================
+-- EMBEDDING NOTIFICATION TRIGGER (for immediate embedding generation)
+-- =============================================================================
+
+-- Function to notify embedding system when new facts need embeddings
 CREATE OR REPLACE FUNCTION notify_m2_embedding_needed()
 RETURNS TRIGGER AS $$
 BEGIN
-    -- Only notify if needs_embedding is TRUE
-    IF NEW.needs_embedding = TRUE THEN
-        PERFORM pg_notify('m2_embedding_needed', NEW.id::text);
+    -- Notify embedding system when new facts are created without embeddings
+    IF NEW.embedding IS NULL AND NEW.text IS NOT NULL THEN
+        PERFORM pg_notify('embedding_needed', 'm2_semantic:' || NEW.fact_id::text);
     END IF;
     RETURN NEW;
 END;
 $$ LANGUAGE plpgsql;
 
--- Create trigger for immediate embedding notifications
-DROP TRIGGER IF EXISTS m2_semantic_embedding_trigger ON m2_semantic;
-CREATE TRIGGER m2_semantic_embedding_trigger
-    AFTER INSERT OR UPDATE OF needs_embedding ON m2_semantic
+-- Trigger for immediate embedding notification
+DROP TRIGGER IF EXISTS trigger_m2_embedding_notification ON m2_semantic;
+CREATE TRIGGER trigger_m2_embedding_notification
+    AFTER INSERT ON m2_semantic
     FOR EACH ROW
     EXECUTE FUNCTION notify_m2_embedding_needed();
 
 -- =============================================================================
--- LINEAGE TABLE
+-- DATA VALIDATION CONSTRAINTS
 -- =============================================================================
 
--- Create lineage table to track fact provenance
-CREATE TABLE IF NOT EXISTS m2_lineage (
-    id TEXT PRIMARY KEY,
-    fact_id TEXT NOT NULL REFERENCES m2_semantic(id) ON DELETE CASCADE,
-    source_type TEXT NOT NULL,  -- m1_episodic, external, inference, etc.
-    source_id TEXT,  -- ID of source record
-    confidence FLOAT NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0),
-    metadata JSONB DEFAULT '{}'::jsonb,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-);
+-- Additional check constraints for data quality
+ALTER TABLE m2_semantic
+    ADD CONSTRAINT check_text_not_empty
+    CHECK (length(trim(text)) > 0);
 
--- Create indexes on lineage table
-CREATE INDEX IF NOT EXISTS idx_m2_lineage_fact_id ON m2_lineage (fact_id);
-CREATE INDEX IF NOT EXISTS idx_m2_lineage_source_type ON m2_lineage (source_type);
-CREATE INDEX IF NOT EXISTS idx_m2_lineage_source_id ON m2_lineage (source_id);
-
--- =============================================================================
--- CONFLICTS TABLE
--- =============================================================================
-
--- Create conflicts table to track and manage conflicting facts
-CREATE TABLE IF NOT EXISTS m2_conflicts (
-    id TEXT PRIMARY KEY,
-    fact_id_1 TEXT NOT NULL REFERENCES m2_semantic(id) ON DELETE CASCADE,
-    fact_id_2 TEXT NOT NULL REFERENCES m2_semantic(id) ON DELETE CASCADE,
-    conflict_type TEXT NOT NULL,  -- contradiction, partial, temporal, etc.
-    conflict_description TEXT,
-    resolution_status TEXT DEFAULT 'unresolved',  -- unresolved, resolved_1, resolved_2, merged, etc.
-    resolution_method TEXT,  -- llm, user, rule, etc.
-    resolution_confidence FLOAT,
-    metadata JSONB DEFAULT '{}'::jsonb,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    resolved_at TIMESTAMP
-);
-
--- Create indexes on conflicts table
-CREATE INDEX IF NOT EXISTS idx_m2_conflicts_fact_id_1 ON m2_conflicts (fact_id_1);
-CREATE INDEX IF NOT EXISTS idx_m2_conflicts_fact_id_2 ON m2_conflicts (fact_id_2);
-CREATE INDEX IF NOT EXISTS idx_m2_conflicts_resolution_status ON m2_conflicts (resolution_status);
-CREATE INDEX IF NOT EXISTS idx_m2_conflicts_created_at ON m2_conflicts (created_at);
+ALTER TABLE m2_semantic
+    ADD CONSTRAINT check_confidence_range
+    CHECK (confidence >= 0.0 AND confidence <= 1.0);
 
 -- =============================================================================
 -- COMMENTS FOR DOCUMENTATION
 -- =============================================================================
 
-COMMENT ON TABLE m2_semantic IS 'M2 Semantic Memory Layer - stores semantic facts extracted from M1 episodic memories with automatic embedding generation';
+COMMENT ON TABLE m2_semantic IS 'M2 Semantic Memory Layer - stores semantic facts with high-performance vector embeddings';
 
-COMMENT ON COLUMN m2_semantic.id IS 'Unique identifier for the semantic fact';
-COMMENT ON COLUMN m2_semantic.source_id IS 'Reference to the M1 episodic memory record this fact was extracted from';
-COMMENT ON COLUMN m2_semantic.fact_content IS 'The semantic fact content';
-COMMENT ON COLUMN m2_semantic.fact_type IS 'Open-ended classification of fact type, extensible for any categorization system';
-COMMENT ON COLUMN m2_semantic.fact_category IS 'Flexible JSONB categorization system for complex fact classification';
+COMMENT ON COLUMN m2_semantic.fact_id IS 'Unique identifier for the semantic fact';
+COMMENT ON COLUMN m2_semantic.text IS 'Semantic fact content optimized for search and retrieval';
+COMMENT ON COLUMN m2_semantic.hash IS 'Hash for idempotency and duplicate detection';
+COMMENT ON COLUMN m2_semantic.embedding IS '384-dimensional vector embedding for similarity search';
 COMMENT ON COLUMN m2_semantic.confidence IS 'Confidence score for fact extraction (0.0 to 1.0)';
-COMMENT ON COLUMN m2_semantic.entities IS 'JSON array of entities mentioned in the fact';
-COMMENT ON COLUMN m2_semantic.temporal_info IS 'JSON object containing temporal information (dates, times, etc.)';
-COMMENT ON COLUMN m2_semantic.is_verified IS 'Whether this fact has been verified';
-COMMENT ON COLUMN m2_semantic.conflict_status IS 'Status of any conflicts with other facts';
-COMMENT ON COLUMN m2_semantic.embedding IS '384-dimensional vector embedding of the fact content';
-COMMENT ON COLUMN m2_semantic.needs_embedding IS 'Flag indicating if this record needs embedding generation';
-
-COMMENT ON TABLE m2_lineage IS 'Tracks the provenance and lineage of facts in the M2 semantic memory layer';
-COMMENT ON TABLE m2_conflicts IS 'Manages conflicts between facts in the M2 semantic memory layer';
+COMMENT ON COLUMN m2_semantic.status IS 'Status of the fact: active or deprecated';
+COMMENT ON COLUMN m2_semantic.chunk_ids IS 'Array of M1 chunk IDs that contributed to this fact (lineage tracking)';
+COMMENT ON COLUMN m2_semantic.user_id IS 'User identifier for multi-tenant isolation';
+COMMENT ON COLUMN m2_semantic.policy_version IS 'Version of extraction policy used to generate this fact';
+COMMENT ON COLUMN m2_semantic.created_at IS 'Timestamp when fact was created';
+COMMENT ON COLUMN m2_semantic.updated_at IS 'Timestamp when fact was last updated';
+COMMENT ON COLUMN m2_semantic.embedding_generated_at IS 'Timestamp when embedding was generated';
+COMMENT ON COLUMN m2_semantic.embedding_model IS 'Model used for embedding generation';
+COMMENT ON COLUMN m2_semantic.metadata IS 'Additional metadata for the semantic fact';

--- a/src/memfuse_core/store/pgai_store/schemas/m2_semantic.sql.bak
+++ b/src/memfuse_core/store/pgai_store/schemas/m2_semantic.sql.bak
@@ -1,0 +1,206 @@
+-- M2 Semantic Memory Layer Schema
+-- This schema defines the m2_semantic table for storing semantic facts
+-- with automatic embedding generation support
+
+-- =============================================================================
+-- M2 SEMANTIC TABLE DEFINITION
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS m2_semantic (
+    -- Primary identification
+    id TEXT PRIMARY KEY,
+    
+    -- Source tracking (links back to M1 episodic memory)
+    source_id TEXT,  -- References m1_episodic.id
+    source_session_id TEXT,  -- Session context for fact
+    source_user_id TEXT,  -- User context for fact
+    
+    -- Fact content and metadata
+    fact_content TEXT NOT NULL,
+    fact_type TEXT,  -- Open-ended fact type, no constraints for extensibility
+    fact_category JSONB DEFAULT '{}'::jsonb,  -- Flexible categorization system
+    confidence FLOAT NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    
+    -- Structured fact data
+    entities JSONB DEFAULT '[]'::jsonb,  -- Extracted entities from fact
+    temporal_info JSONB DEFAULT '{}'::jsonb,  -- Temporal information (dates, times, etc.)
+    source_context TEXT,  -- Brief context about where fact came from
+    
+    -- Semantic-specific fields
+    is_verified BOOLEAN DEFAULT FALSE,  -- Whether fact has been verified
+    verification_method TEXT,  -- How the fact was verified
+    verification_source TEXT,  -- Source of verification
+    verification_confidence FLOAT,  -- Confidence in verification (0.0 to 1.0)
+    
+    -- Conflict management
+    conflict_status TEXT DEFAULT 'none',  -- none, potential, confirmed
+    conflicting_facts JSONB DEFAULT '[]'::jsonb,  -- References to conflicting facts
+    resolution_status TEXT,  -- How conflicts were resolved
+    
+    -- General metadata
+    metadata JSONB DEFAULT '{}'::jsonb,
+    
+    -- PgAI embedding infrastructure (identical to M0/M1)
+    embedding VECTOR(384),  -- 384-dimensional embedding vector
+    needs_embedding BOOLEAN DEFAULT TRUE,  -- Flag for automatic embedding generation
+    retry_count INTEGER DEFAULT 0,  -- Number of embedding retry attempts
+    last_retry_at TIMESTAMP,  -- Timestamp of last retry attempt
+    retry_status TEXT DEFAULT 'pending' CHECK (retry_status IN ('pending', 'processing', 'completed', 'failed')),
+    
+    -- Audit timestamps
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- =============================================================================
+-- PERFORMANCE INDEXES
+-- =============================================================================
+
+-- Primary key index (automatic)
+-- CREATE UNIQUE INDEX m2_semantic_pkey ON m2_semantic USING btree (id);
+
+-- Source tracking indexes
+CREATE INDEX IF NOT EXISTS idx_m2_source_id ON m2_semantic (source_id);
+CREATE INDEX IF NOT EXISTS idx_m2_source_session ON m2_semantic (source_session_id);
+CREATE INDEX IF NOT EXISTS idx_m2_source_user ON m2_semantic (source_user_id);
+
+-- Fact type and confidence indexes
+CREATE INDEX IF NOT EXISTS idx_m2_fact_type ON m2_semantic (fact_type);
+CREATE INDEX IF NOT EXISTS idx_m2_confidence ON m2_semantic (confidence);
+
+-- Verification indexes
+CREATE INDEX IF NOT EXISTS idx_m2_is_verified ON m2_semantic (is_verified);
+CREATE INDEX IF NOT EXISTS idx_m2_verification_confidence ON m2_semantic (verification_confidence);
+
+-- Conflict management indexes
+CREATE INDEX IF NOT EXISTS idx_m2_conflict_status ON m2_semantic (conflict_status);
+CREATE INDEX IF NOT EXISTS idx_m2_resolution_status ON m2_semantic (resolution_status);
+
+-- Auto-embedding query optimization
+CREATE INDEX IF NOT EXISTS idx_m2_needs_embedding ON m2_semantic (needs_embedding) 
+WHERE needs_embedding = TRUE;
+
+-- Retry management indexes
+CREATE INDEX IF NOT EXISTS idx_m2_retry_status ON m2_semantic (retry_status);
+CREATE INDEX IF NOT EXISTS idx_m2_retry_count ON m2_semantic (retry_count);
+
+-- Temporal indexes
+CREATE INDEX IF NOT EXISTS idx_m2_created_at ON m2_semantic (created_at);
+CREATE INDEX IF NOT EXISTS idx_m2_updated_at ON m2_semantic (updated_at);
+
+-- JSONB indexes for structured data
+CREATE INDEX IF NOT EXISTS idx_m2_entities_gin ON m2_semantic USING gin (entities);
+CREATE INDEX IF NOT EXISTS idx_m2_temporal_gin ON m2_semantic USING gin (temporal_info);
+CREATE INDEX IF NOT EXISTS idx_m2_metadata_gin ON m2_semantic USING gin (metadata);
+CREATE INDEX IF NOT EXISTS idx_m2_category_gin ON m2_semantic USING gin (fact_category);
+CREATE INDEX IF NOT EXISTS idx_m2_conflicting_facts_gin ON m2_semantic USING gin (conflicting_facts);
+
+-- Vector similarity search index (will be created after data insertion)
+-- CREATE INDEX IF NOT EXISTS idx_m2_embedding_cosine ON m2_semantic
+--     USING ivfflat (embedding vector_cosine_ops) WITH (lists = 100);
+
+-- =============================================================================
+-- TRIGGERS
+-- =============================================================================
+
+-- Create function to update updated_at timestamp
+CREATE OR REPLACE FUNCTION update_m2_semantic_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = CURRENT_TIMESTAMP;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger for automatic updated_at updates
+DROP TRIGGER IF EXISTS m2_semantic_updated_at_trigger ON m2_semantic;
+CREATE TRIGGER m2_semantic_updated_at_trigger
+    BEFORE UPDATE ON m2_semantic
+    FOR EACH ROW
+    EXECUTE FUNCTION update_m2_semantic_updated_at();
+
+-- Create notification function for immediate embedding generation
+CREATE OR REPLACE FUNCTION notify_m2_embedding_needed()
+RETURNS TRIGGER AS $$
+BEGIN
+    -- Only notify if needs_embedding is TRUE
+    IF NEW.needs_embedding = TRUE THEN
+        PERFORM pg_notify('m2_embedding_needed', NEW.id::text);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Create trigger for immediate embedding notifications
+DROP TRIGGER IF EXISTS m2_semantic_embedding_trigger ON m2_semantic;
+CREATE TRIGGER m2_semantic_embedding_trigger
+    AFTER INSERT OR UPDATE OF needs_embedding ON m2_semantic
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_m2_embedding_needed();
+
+-- =============================================================================
+-- LINEAGE TABLE
+-- =============================================================================
+
+-- Create lineage table to track fact provenance
+CREATE TABLE IF NOT EXISTS m2_lineage (
+    id TEXT PRIMARY KEY,
+    fact_id TEXT NOT NULL REFERENCES m2_semantic(id) ON DELETE CASCADE,
+    source_type TEXT NOT NULL,  -- m1_episodic, external, inference, etc.
+    source_id TEXT,  -- ID of source record
+    confidence FLOAT NOT NULL CHECK (confidence >= 0.0 AND confidence <= 1.0),
+    metadata JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Create indexes on lineage table
+CREATE INDEX IF NOT EXISTS idx_m2_lineage_fact_id ON m2_lineage (fact_id);
+CREATE INDEX IF NOT EXISTS idx_m2_lineage_source_type ON m2_lineage (source_type);
+CREATE INDEX IF NOT EXISTS idx_m2_lineage_source_id ON m2_lineage (source_id);
+
+-- =============================================================================
+-- CONFLICTS TABLE
+-- =============================================================================
+
+-- Create conflicts table to track and manage conflicting facts
+CREATE TABLE IF NOT EXISTS m2_conflicts (
+    id TEXT PRIMARY KEY,
+    fact_id_1 TEXT NOT NULL REFERENCES m2_semantic(id) ON DELETE CASCADE,
+    fact_id_2 TEXT NOT NULL REFERENCES m2_semantic(id) ON DELETE CASCADE,
+    conflict_type TEXT NOT NULL,  -- contradiction, partial, temporal, etc.
+    conflict_description TEXT,
+    resolution_status TEXT DEFAULT 'unresolved',  -- unresolved, resolved_1, resolved_2, merged, etc.
+    resolution_method TEXT,  -- llm, user, rule, etc.
+    resolution_confidence FLOAT,
+    metadata JSONB DEFAULT '{}'::jsonb,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    resolved_at TIMESTAMP
+);
+
+-- Create indexes on conflicts table
+CREATE INDEX IF NOT EXISTS idx_m2_conflicts_fact_id_1 ON m2_conflicts (fact_id_1);
+CREATE INDEX IF NOT EXISTS idx_m2_conflicts_fact_id_2 ON m2_conflicts (fact_id_2);
+CREATE INDEX IF NOT EXISTS idx_m2_conflicts_resolution_status ON m2_conflicts (resolution_status);
+CREATE INDEX IF NOT EXISTS idx_m2_conflicts_created_at ON m2_conflicts (created_at);
+
+-- =============================================================================
+-- COMMENTS FOR DOCUMENTATION
+-- =============================================================================
+
+COMMENT ON TABLE m2_semantic IS 'M2 Semantic Memory Layer - stores semantic facts extracted from M1 episodic memories with automatic embedding generation';
+
+COMMENT ON COLUMN m2_semantic.id IS 'Unique identifier for the semantic fact';
+COMMENT ON COLUMN m2_semantic.source_id IS 'Reference to the M1 episodic memory record this fact was extracted from';
+COMMENT ON COLUMN m2_semantic.fact_content IS 'The semantic fact content';
+COMMENT ON COLUMN m2_semantic.fact_type IS 'Open-ended classification of fact type, extensible for any categorization system';
+COMMENT ON COLUMN m2_semantic.fact_category IS 'Flexible JSONB categorization system for complex fact classification';
+COMMENT ON COLUMN m2_semantic.confidence IS 'Confidence score for fact extraction (0.0 to 1.0)';
+COMMENT ON COLUMN m2_semantic.entities IS 'JSON array of entities mentioned in the fact';
+COMMENT ON COLUMN m2_semantic.temporal_info IS 'JSON object containing temporal information (dates, times, etc.)';
+COMMENT ON COLUMN m2_semantic.is_verified IS 'Whether this fact has been verified';
+COMMENT ON COLUMN m2_semantic.conflict_status IS 'Status of any conflicts with other facts';
+COMMENT ON COLUMN m2_semantic.embedding IS '384-dimensional vector embedding of the fact content';
+COMMENT ON COLUMN m2_semantic.needs_embedding IS 'Flag indicating if this record needs embedding generation';
+
+COMMENT ON TABLE m2_lineage IS 'Tracks the provenance and lineage of facts in the M2 semantic memory layer';
+COMMENT ON TABLE m2_conflicts IS 'Manages conflicts between facts in the M2 semantic memory layer';

--- a/tests/unit/models/test_m2_status.py
+++ b/tests/unit/models/test_m2_status.py
@@ -1,0 +1,58 @@
+"""
+Unit tests for M2Status enum.
+
+Tests the M2Status enum values and completeness for M2 fact extraction
+processing status tracking.
+"""
+
+import pytest
+from src.memfuse_core.models.core import M2Status
+
+
+class TestM2Status:
+    """Test cases for M2Status enum."""
+    
+    def test_m2_status_enum_values(self):
+        """Test M2Status enum has correct values."""
+        assert M2Status.PENDING == "pending"
+        assert M2Status.PROCESSING == "processing" 
+        assert M2Status.COMPLETED == "completed"
+        assert M2Status.FAILED == "failed"
+    
+    def test_m2_status_enum_completeness(self):
+        """Test M2Status enum has all expected values and no extras."""
+        expected_values = {"pending", "processing", "completed", "failed"}
+        actual_values = {status.value for status in M2Status}
+        assert actual_values == expected_values
+    
+    def test_m2_status_enum_string_representation(self):
+        """Test M2Status enum string representation."""
+        assert str(M2Status.PENDING) == "M2Status.PENDING"
+        assert str(M2Status.PROCESSING) == "M2Status.PROCESSING"
+        assert str(M2Status.COMPLETED) == "M2Status.COMPLETED"
+        assert str(M2Status.FAILED) == "M2Status.FAILED"
+    
+    def test_m2_status_enum_membership(self):
+        """Test checking membership in M2Status enum."""
+        assert M2Status.PENDING in M2Status
+        assert M2Status.PROCESSING in M2Status
+        assert M2Status.COMPLETED in M2Status
+        assert M2Status.FAILED in M2Status
+        
+        # Test invalid values are not members
+        assert "invalid_status" not in [s.value for s in M2Status]
+    
+    def test_m2_status_enum_iteration(self):
+        """Test iterating over M2Status enum."""
+        statuses = list(M2Status)
+        assert len(statuses) == 4
+        
+        values = [status.value for status in statuses]
+        assert "pending" in values
+        assert "processing" in values
+        assert "completed" in values
+        assert "failed" in values
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/unit/store/pgai_store/test_schema_manager.py
+++ b/tests/unit/store/pgai_store/test_schema_manager.py
@@ -19,22 +19,36 @@ class TestSchemaManager:
     @pytest.fixture
     def mock_pool(self):
         """Mock database connection pool."""
-        pool = AsyncMock()
+        pool = Mock()
         
-        # Mock connection context manager
+        # Mock connection and cursor
         mock_conn = AsyncMock()
         mock_cursor = AsyncMock()
         
-        # Setup connection context manager
-        pool.connection.return_value.__aenter__.return_value = mock_conn
-        pool.connection.return_value.__aexit__.return_value = None
+        # Create proper async context manager for pool.connection()
+        class MockConnection:
+            async def __aenter__(self):
+                return mock_conn
+            
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
         
-        # Setup cursor context manager
-        mock_conn.cursor.return_value.__aenter__.return_value = mock_cursor
-        mock_conn.cursor.return_value.__aexit__.return_value = None
+        # Create async context manager for cursor
+        class MockCursor:
+            async def __aenter__(self):
+                return mock_cursor
+            
+            async def __aexit__(self, exc_type, exc_val, exc_tb):
+                return None
         
-        # Setup execute and fetchall methods
-        mock_conn.execute = AsyncMock()
+        pool.connection = Mock(return_value=MockConnection())
+        mock_conn.cursor = Mock(return_value=MockCursor())
+        
+        # Create a mock result object for conn.execute() calls
+        mock_result = AsyncMock()
+        
+        # Setup execute to return the mock result
+        mock_conn.execute = AsyncMock(return_value=mock_result)
         mock_conn.commit = AsyncMock()
         mock_conn.rollback = AsyncMock()
         
@@ -42,18 +56,19 @@ class TestSchemaManager:
         mock_cursor.fetchall = AsyncMock()
         mock_cursor.fetchone = AsyncMock()
         
-        return pool, mock_conn, mock_cursor
+        return pool, mock_conn, mock_cursor, mock_result
     
     def test_initialization(self, mock_pool):
         """Test SchemaManager initialization."""
-        pool, _, _ = mock_pool
+        pool, _, _, _ = mock_pool
         
         manager = SchemaManager(pool)
         
         assert manager.pool == pool
-        assert manager.current_version == "1.0.0"
         assert "m0" in manager.supported_layers
         assert "m1" in manager.supported_layers
+        assert "m2" in manager.supported_layers
+        assert len(manager.supported_layers) == 3
     
     @pytest.mark.asyncio
     async def test_create_schema_version_table(self, mock_pool):
@@ -423,6 +438,135 @@ class TestSchemaManager:
         assert params[1] == "m0"     # layer_name
         
         mock_conn.commit.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_initialize_m2_schema_success(self, mock_pool):
+        """Test successful M2 schema initialization."""
+        pool, mock_conn, _, _ = mock_pool
+        
+        manager = SchemaManager(pool)
+        
+        # Mock schema file exists and has content
+        mock_schema_content = """
+        CREATE TABLE m2_semantic (
+            fact_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            text TEXT NOT NULL,
+            embedding vector(384)
+        );
+        """
+        
+        with patch('pathlib.Path.exists', return_value=True), \
+             patch('pathlib.Path.read_text', return_value=mock_schema_content):
+            
+            result = await manager._initialize_m2_schema()
+        
+        assert result is True
+        
+        # Verify schema SQL was executed
+        mock_conn.execute.assert_called_once_with(mock_schema_content)
+        mock_conn.commit.assert_called_once()
+    
+    @pytest.mark.asyncio
+    async def test_initialize_m2_schema_file_not_found(self, mock_pool):
+        """Test M2 schema initialization when schema file is missing."""
+        pool, _, _, _ = mock_pool
+        
+        manager = SchemaManager(pool)
+        
+        # Mock schema file doesn't exist
+        with patch('pathlib.Path.exists', return_value=False):
+            result = await manager._initialize_m2_schema()
+        
+        assert result is False
+    
+    @pytest.mark.asyncio
+    async def test_validate_m2_schema_success(self, mock_pool):
+        """Test successful M2 schema validation."""
+        pool, mock_conn, mock_cursor, mock_result = mock_pool
+        
+        manager = SchemaManager(pool)
+        
+        # Mock table exists and column count checks
+        mock_result.fetchone = AsyncMock(side_effect=[
+            (True,),  # Table exists check
+            (4,)      # Column count check
+        ])
+        
+        result = await manager._validate_m2_schema()
+        
+        assert result is True
+        
+        # Verify execute was called twice (table existence and column count)
+        assert mock_conn.execute.call_count == 2
+        
+        # Check the SQL queries were executed
+        execute_calls = mock_conn.execute.call_args_list
+        
+        # Check first query (table existence)
+        first_query = execute_calls[0][0][0]
+        assert "SELECT EXISTS" in first_query
+        assert "table_name = 'm2_semantic'" in first_query
+        
+        # Check second query (column count)
+        second_query = execute_calls[1][0][0]
+        assert "SELECT COUNT(*)" in second_query
+        assert "table_name = 'm2_semantic'" in second_query
+        assert "column_name IN ('fact_id', 'text', 'embedding', 'confidence')" in second_query
+    
+    @pytest.mark.asyncio
+    async def test_validate_m2_schema_missing_table(self, mock_pool):
+        """Test M2 schema validation when table doesn't exist."""
+        pool, mock_conn, mock_cursor, mock_result = mock_pool
+        
+        manager = SchemaManager(pool)
+        
+        # Mock table doesn't exist
+        mock_result.fetchone = AsyncMock(return_value=(False,))
+        
+        result = await manager._validate_m2_schema()
+        
+        assert result is False
+    
+    @pytest.mark.asyncio
+    async def test_validate_m2_schema_missing_columns(self, mock_pool):
+        """Test M2 schema validation when required columns are missing."""
+        pool, mock_conn, mock_cursor, mock_result = mock_pool
+        
+        manager = SchemaManager(pool)
+        
+        # Mock table exists but missing columns
+        mock_result.fetchone = AsyncMock(side_effect=[
+            (True,),  # Table exists
+            (2,)      # Only 2 columns instead of required 4
+        ])
+        
+        result = await manager._validate_m2_schema()
+        
+        assert result is False
+    
+    @pytest.mark.asyncio
+    async def test_initialize_all_schemas_with_m2(self, mock_pool):
+        """Test successful initialization of all schemas including M2."""
+        pool, mock_conn, mock_cursor, mock_result = mock_pool
+        
+        manager = SchemaManager(pool)
+        
+        # Mock schema version checks to return False (needs initialization)
+        mock_cursor.fetchone.return_value = None
+        
+        # Mock M1 and M2 schema file reading
+        mock_schema_content = "CREATE TABLE test_table (id UUID PRIMARY KEY);"
+        
+        with patch('pathlib.Path.exists', return_value=True), \
+             patch('pathlib.Path.read_text', return_value=mock_schema_content):
+            
+            result = await manager.initialize_all_schemas(['m0', 'm1', 'm2'])
+        
+        assert result is True
+        
+        # Verify schema operations were performed
+        assert mock_conn.execute.call_count >= 3  # At least one for each layer
+        assert mock_conn.commit.call_count >= 3
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
…d validation

- Introduced M2 semantic memory layer in the database with the creation of the `m2_semantic` table.
- Updated `SimplifiedDatabaseManager` to handle M2 table creation and validation.
- Enhanced `SchemaManager` to support M2 schema initialization and validation.
- Added new SQL schema file for `m2_semantic` with necessary fields and constraints.
- Implemented M2 processing status tracking in the `m1_episodic` table.
- Created unit tests for M2 status enum and schema manager functionalities.