### PR TITLE
fix: Add missing M2 status fields to Docker initialization schema

### DIFF
--- a/docker/pgvectorscale/init-scripts/00-init-memfuse-pgai.sql
+++ b/docker/pgvectorscale/init-scripts/00-init-memfuse-pgai.sql
@@ -132,6 +132,12 @@ CREATE TABLE IF NOT EXISTS m1_episodic (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
     embedding_generated_at TIMESTAMP WITH TIME ZONE,
 
+    -- M2 processing status tracking
+    m2_status VARCHAR(20) DEFAULT 'pending'
+        CHECK (m2_status IN ('pending', 'processing', 'completed', 'failed')),
+    m2_processing_started_at TIMESTAMP WITH TIME ZONE,
+    m2_processing_ended_at TIMESTAMP WITH TIME ZONE,
+
     -- Quality metrics
     embedding_model VARCHAR(100) DEFAULT 'sentence-transformers/all-MiniLM-L6-v2',
     chunk_quality_score FLOAT DEFAULT 0.0,
@@ -220,6 +226,16 @@ CREATE INDEX IF NOT EXISTS idx_m1_needs_embedding
 -- GIN index for M0 message ID arrays (lineage queries)
 CREATE INDEX IF NOT EXISTS idx_m1_m0_raw_ids_gin
     ON m1_episodic USING gin (m0_raw_ids);
+
+-- M2 processing status indexes
+CREATE INDEX IF NOT EXISTS idx_m1_m2_status
+    ON m1_episodic (m2_status);
+
+CREATE INDEX IF NOT EXISTS idx_m1_m2_processing_started_at
+    ON m1_episodic (m2_processing_started_at);
+
+CREATE INDEX IF NOT EXISTS idx_m1_m2_processing_ended_at
+    ON m1_episodic (m2_processing_ended_at);
 
 -- GIN index for metadata queries
 CREATE INDEX IF NOT EXISTS idx_m1_metadata_gin


### PR DESCRIPTION
The m1_episodic table was missing M2 processing status fields because the Docker initialization script runs before the MemFuse application, creating the table with an incomplete schema.

Changes:
- Add m2_status column with CHECK constraint for status validation
- Add m2_processing_started_at and m2_processing_ended_at timestamp columns
- Add corresponding indexes for M2 status fields to optimize queries

Root Cause:
Docker init script (00-init-memfuse-pgai.sql) executes during container startup before application code, so CREATE TABLE IF NOT EXISTS in the app sees existing table and skips creation with updated schema.

Fixes: Missing M2 status tracking functionality in episodic memory layer